### PR TITLE
Use custom fetcher to catch assets errors while generating pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pip install pipenv
 PIPENV_VENV_IN_PROJECT=true pipenv install
 ```
 
+Install apt :
 ```bash
 apt install python3-flask weasyprint
 ```
@@ -21,7 +22,7 @@ apt install python3-flask weasyprint
 ### en local
 
 ```bash
-flask run --host=0.0.0.0 -H ${CWD}/.venv # par défaut sur port 5000`
+flask run --host=0.0.0.0 -h ${CWD}/.venv # par défaut sur port 5000`
 ```
 
 Une variable d'environnement `BASE_URL` doit pointer vers le serveur qui contient les assets,

--- a/app.py
+++ b/app.py
@@ -4,27 +4,28 @@ import logging
 from flask import Flask, request, make_response
 from weasyprint import HTML
 
-LOG_PATH = os.path.join(os.path.abspath(os.getcwd()), 'log')
-LOG_FILE = os.path.join(LOG_PATH, 'weasyprint.log')
+LOG_PATH = os.path.join(os.path.abspath(os.getcwd()), "log")
+LOG_FILE = os.path.join(LOG_PATH, "weasyprint.log")
 
-logger = logging.getLogger('weasyprint')
+logger = logging.getLogger("weasyprint")
 logger.addHandler(logging.FileHandler(LOG_FILE))
 
-try:  
-   BASE_URL = os.environ['BASE_URL']
-except KeyError: 
-   print("missing BASE_URL env var to fetch the assets (css, images ...)")
-   sys.exit(1)
+try:
+    BASE_URL = os.environ["BASE_URL"]
+except KeyError:
+    print("missing BASE_URL env var to fetch the assets (css, images ...)")
+    sys.exit(1)
 
 app = Flask(__name__)
 
-@app.route('/pdf', methods=['POST'])
+
+@app.route("/pdf", methods=["POST"])
 def pdf():
     request_data = request.get_json()
-    string_html = request_data['html']
+    string_html = request_data["html"]
     html = HTML(string=string_html, base_url=BASE_URL)
     pdf = html.write_pdf()
-    response = make_response( pdf )
-    response.headers['Content-Type'] = 'application/pdf'
-    response.headers['Content-Disposition'] = 'inline;filename=fichier'
+    response = make_response(pdf)
+    response.headers["Content-Type"] = "application/pdf"
+    response.headers["Content-Disposition"] = "inline;filename=fichier"
     return response

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import sys
 import logging
 from flask import Flask, request, make_response
 from weasyprint import HTML
+from custom_fetcher import custom_url_fetcher
 
 LOG_PATH = os.path.join(os.path.abspath(os.getcwd()), "log")
 LOG_FILE = os.path.join(LOG_PATH, "weasyprint.log")
@@ -23,8 +24,12 @@ app = Flask(__name__)
 def pdf():
     request_data = request.get_json()
     string_html = request_data["html"]
-    html = HTML(string=string_html, base_url=BASE_URL)
-    pdf = html.write_pdf()
+    html = HTML(string=string_html, base_url=BASE_URL, url_fetcher=custom_url_fetcher)
+    try:
+        pdf = html.write_pdf()
+    # See the hack in custom_fetcher.py
+    except AttributeError as e:
+        return str(e), 500
     response = make_response(pdf)
     response.headers["Content-Type"] = "application/pdf"
     response.headers["Content-Disposition"] = "inline;filename=fichier"

--- a/custom_fetcher.py
+++ b/custom_fetcher.py
@@ -1,0 +1,13 @@
+from weasyprint.urls import default_url_fetcher
+from urllib.error import URLError
+
+
+def custom_url_fetcher(url, timeout=10, ssl_context=None):
+    try:
+        result = default_url_fetcher(url, timeout, ssl_context)
+    except URLError:
+        # Ugly hack:
+        # the caller swallows all `Exception`
+        # but raise an AttributeError if the result is None
+        result = None
+    return result


### PR DESCRIPTION
better logs (time in log file, and not in stdout for uwsgi)

Ugly way to abord rendering in case of fetch error