### PR TITLE
feat: add docker configuration for both dev and production

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,23 @@ uv run ruff format --check && uv run ruff check
 ## Packaging
 
 voir package_scripts/main.sh
+
+## Fonctionnement
+
+Une fois l’app installée on peut vérifier qu’elle fonctionne avec :
+
+```sh
+curl -X POST \
+  http://localhost:5000/pdf \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<html><body><h1>Test</h1></body></html>"}' \
+  --output test.pdf
+```
+
+## Build
+
+Pour la production :
+
+```sh
+docker build -f ops/production/Dockerfile -t NAME .
+```

--- a/ops/dev/Dockerfile
+++ b/ops/dev/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:12-slim
+
+ARG UV_VERSION=0.5.4
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 \
+  ca-certificates \
+  weasyprint \
+  curl && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C /usr/local/bin --strip-components=1
+
+RUN groupadd -g "${GROUP_ID}" app && \
+    useradd --create-home --no-log-init -u "${USER_ID}" -g "${GROUP_ID}" app
+
+USER app
+
+WORKDIR /home/app
+
+RUN uv venv /home/app/venv
+ENV PATH="/home/app/venv/bin:$PATH"
+
+RUN uv pip install -e .
+
+CMD ["python3", "-m", "flask", "--app", "src.app:create_app()", "run", "--host=0.0.0.0"]

--- a/ops/dev/app_env
+++ b/ops/dev/app_env
@@ -1,0 +1,1 @@
+BASE_URL=http://localhost:5000

--- a/ops/dev/docker-compose.yml
+++ b/ops/dev/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.7'
+x-app_common:
+  &app_common
+  build:
+    context: ../../
+    dockerfile: ops/dev/Dockerfile
+    args:
+      UV_VERSION: 0.5.4
+      # use the user id and group id matching the host user
+      USER_ID: 1000
+      GROUP_ID: 1001
+  env_file:
+    - app_env
+  stdin_open: true
+  tty: true
+  volumes:
+    - app_data:/home/app
+  ports:
+    - 5000
+
+services:
+  app:
+    <<: *app_common
+
+volumes:
+  app_data:
+    driver_opts:
+      type: none
+      device: "${PWD}/../../"
+      o: bind

--- a/ops/production/Dockerfile
+++ b/ops/production/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:12-slim
+
+ARG UV_VERSION=0.5.4
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PIP_NO_CACHE_DIR=1
+ENV GUNICORN_WORKERS=4
+ENV APP_PORT=5000
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 \
+  ca-certificates \
+  tini \
+  weasyprint \
+  curl && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C /usr/local/bin --strip-components=1
+
+RUN groupadd -g "${GROUP_ID}" app && \
+    useradd --create-home --no-log-init -u "${USER_ID}" -g "${GROUP_ID}" app
+
+USER app
+
+WORKDIR /home/app
+
+COPY --chown=app:app src/ src/
+COPY --chown=app:app pyproject.toml .
+
+ENV PATH="/home/app/venv/bin:$PATH"
+RUN uv venv /home/app/venv && \
+    . /home/app/venv/bin/activate && \
+    uv pip install -e . && \
+    uv pip install gunicorn
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["gunicorn", "--workers=${GUNICORN_WORKERS}", "--bind=0.0.0.0:${APP_PORT}", "src.app:create_app()"]


### PR DESCRIPTION
J’ai ajouté deux Dockerfile pour le mode dev et production pour pouvoir construire une image du service.

Dans la partie production je suis parti sur gunicorn pour l’éxécution. J’ai gardé uv pour la partie gestion des paquets comme c’était fin initialement.