### PR TITLE
fix: isolate WeasyPrint in subprocess to survive segfaults

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import multiprocessing
 from flask import Flask, request, make_response
 from werkzeug.exceptions import HTTPException
 from weasyprint import HTML
@@ -9,6 +10,43 @@ from .logger import ERROR_LOGGER, ACCESS_LOGGER
 import time
 import json
 import datetime
+
+
+def _pdf_worker(html_string, base_url, queue):
+    """Runs WeasyPrint in an isolated subprocess to survive segfaults."""
+    try:
+        html = HTML(
+            string=html_string, base_url=base_url, url_fetcher=custom_url_fetcher
+        )
+        pdf = html.write_pdf()
+        queue.put(("ok", pdf))
+    except AttributeError:
+        queue.put(("missing_asset", None))
+    except Exception as e:
+        queue.put(("error", str(e)))
+
+
+def _generate_pdf(html_string, base_url):
+    ctx = multiprocessing.get_context("fork")
+    queue = ctx.Queue()
+    process = ctx.Process(target=_pdf_worker, args=(html_string, base_url, queue))
+    process.start()
+    process.join(timeout=120)
+
+    if process.is_alive():
+        process.kill()
+        process.join()
+        raise TimeoutError("PDF generation timed out")
+
+    if not queue.empty():
+        status, result = queue.get_nowait()
+        if status == "ok":
+            return result
+        if status == "missing_asset":
+            raise AttributeError("an asset is missing")
+        raise RuntimeError(result)
+
+    raise RuntimeError(f"PDF generation crashed (exit code {process.exitcode})")
 
 
 def before_send(event, _hint):
@@ -52,17 +90,18 @@ def create_app(test_config=None):
     def pdf():
         request_data = request.get_json()
         string_html = request_data["html"]
-        html = HTML(
-            string=string_html,
-            base_url=app.config["BASE_URL"],
-            url_fetcher=custom_url_fetcher,
-        )
         try:
-            generated_pdf = html.write_pdf()
+            generated_pdf = _generate_pdf(string_html, app.config["BASE_URL"])
         # See the hack in custom_fetcher.py
         except AttributeError:
             sentry_sdk.capture_message("An asset is missing")
             return make_response({"error": "an asset is missing"}, 500)
+        except RuntimeError as e:
+            ERROR_LOGGER.error(
+                "PDF generation crashed", extra={"context": {"error": str(e)}}
+            )
+            sentry_sdk.capture_message(f"PDF generation crashed: {e}")
+            return make_response({"error": "pdf generation crashed"}, 500)
 
         response = make_response(generated_pdf)
         response.headers["Content-Type"] = "application/pdf"

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,8 +1,10 @@
 import json
+import os
 import http.server
 import socketserver
 import threading
 from unittest import TestCase
+from unittest.mock import patch
 from src.app import create_app
 
 
@@ -69,3 +71,17 @@ class TestIntegrations(TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.headers["Content-Type"], "application/json")
         self.assertEqual(response.get_json(), {"error": "an asset is missing"})
+
+    def test_generation_crash_returns_500(self):
+        def crashing_worker(html_string, base_url, queue):
+            os.abort()
+
+        with patch("src.app._pdf_worker", crashing_worker):
+            response = self.app.post(
+                "/pdf",
+                data=json.dumps({"html": "<h1>test</h1>"}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.get_json(), {"error": "pdf generation crashed"})


### PR DESCRIPTION
## Problème

Quand WeasyPrint génère un segfault (exit 139), il tue le process Flask entier. L'`errorhandler` ne peut pas intercepter un SIGSEGV — le process est simplement mort.

J'ai constaté ça en local plusieurs fois, de manière aléatoire.  En cas d'erreur on veut pas crasher le service, je ne sais pas si ça impacte la prod régulièrement ou pas.

## Solution

Lancer WeasyPrint dans un sous-process `fork` isolé via `multiprocessing`. Si le sous-process segfault :
- Le process Flask parent survit
- La queue est vide → `RuntimeError` levée
- Flask renvoie un 500 propre avec `{"error": "pdf generation crashed"}`
- Le crash est loggé et envoyé à Sentry

## Test

Ajout d'un test qui simule un vrai crash de subprocess via `os.abort()` et vérifie que le serveur répond bien 500.