### PR TITLE
feat: support optional pdf_variant in /pdf payload

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -53,13 +53,14 @@ def create_app(test_config=None):
     def pdf():
         request_data = request.get_json()
         string_html = request_data["html"]
+        pdf_variant = request_data.get("pdf_variant")
         html = HTML(
             string=string_html,
             base_url=app.config["BASE_URL"],
             url_fetcher=CustomURLFetcher(),
         )
         try:
-            generated_pdf = html.write_pdf()
+            generated_pdf = html.write_pdf(pdf_variant=pdf_variant)
         except FatalURLFetchingError:
             sentry_sdk.capture_message("An asset is missing")
             return make_response({"error": "an asset is missing"}, 500)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,9 +1,24 @@
 import json
+import re
+import zlib
 import http.server
 import socketserver
 import threading
 from unittest import TestCase
 from src.app import create_app
+
+
+def pdf_contains(pdf_bytes, needle):
+    """Search needle in a PDF, decoding FlateDecode streams along the way."""
+    if needle in pdf_bytes:
+        return True
+    for stream in re.findall(rb"stream\r?\n(.*?)\r?\nendstream", pdf_bytes, re.DOTALL):
+        try:
+            if needle in zlib.decompress(stream):
+                return True
+        except zlib.error:
+            continue
+    return False
 
 
 PORT = 8000
@@ -56,6 +71,21 @@ class TestIntegrations(TestCase):
         self.assertEqual(
             response.headers["Content-Disposition"], "inline;filename=fichier"
         )
+
+    def test_generation_with_pdf_ua_variant(self):
+        html = '<link rel="stylesheet" type="text/css" href="main.css" /> <h1>Hello, world!</h1>'
+        data = {"html": html, "pdf_variant": "pdf/ua-1"}
+
+        response = self.app.post(
+            "/pdf",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/pdf")
+        # The PDF/UA variant embeds an XMP metadata stream tagging the document
+        # as PDF/UA (pdfuaid namespace) and enables accessibility tags.
+        self.assertTrue(pdf_contains(response.data, b"pdfuaid"))
 
     def test_failing_generation_caused_by_missing_assets(self):
         html = '<link rel="stylesheet" type="text/css" href="missing.css" /> <h1>Hello, world!</h1>'


### PR DESCRIPTION
## Objectif

Accepter un champ optionnel `pdf_variant` dans le payload JSON de `POST /pdf`, transmis tel quel à `HTML(...).write_pdf(pdf_variant=...)`.

- **Champ absent** → comportement actuel inchangé (`pdf_variant=None`, la valeur par défaut de WeasyPrint).
- **Champ présent** (ex. `"pdf/ua-1"`) → génère un PDF conforme PDF/UA avec les tags d'accessibilité (WeasyPrint active automatiquement `pdf_tags=True` pour cette variante).

## Exemple de requête

```json
{ "html": "...", "pdf_variant": "pdf/ua-1" }
```

## Tests

- Nouveau test `test_generation_with_pdf_ua_variant` : vérifie qu'une requête avec `pdf_variant: "pdf/ua-1"` produit un PDF contenant le marqueur `pdfuaid` (helper `pdf_contains` qui décompresse les flux FlateDecode).
- Le cas nominal sans option reste couvert par `test_simple_generation`.

> ⚠️ A déployer si possible avant [la PR qui demande les variants de pdf côté DN](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13314) mais pas obligatoire, les 2 PRs fonctionnent de façon indépendante.
