### PR TITLE
feat: read pdf_variant from upstream_context

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -53,7 +53,8 @@ def create_app(test_config=None):
     def pdf():
         request_data = request.get_json()
         string_html = request_data["html"]
-        pdf_variant = request_data.get("pdf_variant")
+        upstream_context = request_data.get("upstream_context") or {}
+        pdf_variant = upstream_context.get("pdf_variant")
         html = HTML(
             string=string_html,
             base_url=app.config["BASE_URL"],

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -74,7 +74,7 @@ class TestIntegrations(TestCase):
 
     def test_generation_with_pdf_ua_variant(self):
         html = '<link rel="stylesheet" type="text/css" href="main.css" /> <h1>Hello, world!</h1>'
-        data = {"html": html, "pdf_variant": "pdf/ua-1"}
+        data = {"html": html, "upstream_context": {"pdf_variant": "pdf/ua-1"}}
 
         response = self.app.post(
             "/pdf",


### PR DESCRIPTION
## Contexte

Suite à #45, DN envoie finalement le champ `pdf_variant` **imbriqué dans `upstream_context`** et non plus à la racine du payload.

## Changement

Lecture de `pdf_variant` depuis `request_data["upstream_context"]["pdf_variant"]` :

```python
upstream_context = request_data.get("upstream_context") or {}
pdf_variant = upstream_context.get("pdf_variant")
```

- `upstream_context` absent → `pdf_variant=None` → comportement nominal inchangé.
- `upstream_context` présent avec `pdf_variant` (ex. `"pdf/ua-1"`) → PDF conforme PDF/UA.

## Exemple de requête

```json
{ "html": "...", "upstream_context": { "pdf_variant": "pdf/ua-1" } }
```

## Tests

- `test_generation_with_pdf_ua_variant` mis à jour pour envoyer la variante via `upstream_context`.
- Cas nominal toujours couvert par `test_simple_generation`.
